### PR TITLE
Update mass_mailer file with checks

### DIFF
--- a/email/mass_mailer
+++ b/email/mass_mailer
@@ -4,10 +4,20 @@ addrfile="addresses-${kernel_version}"
 subject="Linux kernel development reports for the ${kernel_version} release"
 msg="email_message"
 
-for address in `cat $addrfile`
+if [ ! -f "$addrfile" ] ; then
+	echo "Error: $addrfile file not found"
+	exit 1
+fi
+
+if [ ! -f "$msg" ] ; then
+	echo "Error: $msg file not found"
+	exit 1
+fi
+
+while read -r address
 do
 	echo "sending message for ${kernel_version} to $address"
 	mutt -s "$subject" "$address" <  $msg >> spam.log 2>&1
 #	sleep 1
-done
+done < "$addrfile"
 


### PR DESCRIPTION

This script has few improvements:

- It checks if the addrfile and msg file exist before proceeding, which will prevent errors if the files are not found.
- Instead of using backticks, it uses a while loop to read addresses from the addrfile, which is more readable and safer.